### PR TITLE
refactor: API 응답 및 요청 처리 로직 개선

### DIFF
--- a/order-service/src/main/java/com/example/orderservice/client/ProductServiceClient.java
+++ b/order-service/src/main/java/com/example/orderservice/client/ProductServiceClient.java
@@ -1,6 +1,7 @@
 package com.example.orderservice.client;
 
 import com.example.orderservice.dto.request.StockRequest;
+import com.example.orderservice.dto.response.ApiResponse;
 import com.example.orderservice.dto.response.ProductResponse;
 import com.example.orderservice.dto.response.ProductStockResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -17,5 +18,5 @@ public interface ProductServiceClient {
     void saveProductStock(@RequestBody StockRequest stockRequest);
 
     @GetMapping("/products/{productId}")
-    ProductResponse getProduct(@PathVariable Long productId);
+    ApiResponse<ProductResponse> getProduct(@PathVariable Long productId);
 }

--- a/order-service/src/main/java/com/example/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/com/example/orderservice/controller/OrderController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/order-service")
+@RequestMapping("/")
 public class OrderController {
     OrderService orderService;
 
@@ -47,7 +47,7 @@ public class OrderController {
     }
 
     @GetMapping("/orders")
-    public ApiResponse<List<OrderProductResponse>> getOrders(@RequestParam Long userId ){
+    public ApiResponse<List<OrderProductResponse>> getOrders(@RequestHeader("X-User-Id") Long userId){
         List<OrderProductResponse> orderList = orderService.getOrdersByUserId(Long.valueOf(userId));
         return ApiResponse.success(orderList);
     }

--- a/order-service/src/main/java/com/example/orderservice/service/OrderServiceImpl.java
+++ b/order-service/src/main/java/com/example/orderservice/service/OrderServiceImpl.java
@@ -200,7 +200,7 @@ public class OrderServiceImpl implements OrderService {
         // 주문 상품 목록을 Response값으로 변환
         List<OrderProductResponse> orderProductResponseList = new ArrayList<>();
         for (OrderProductEntity orderProductEntity : orderProductEntities) {
-            ProductResponse productResponse = productService.getProduct(orderProductEntity.getProductId());
+            ProductResponse productResponse = productService.getProduct(orderProductEntity.getProductId()).getResult();
             orderProductResponseList.add(OrderProductResponse.fromEntity(orderProductEntity, productResponse.getName()));
         }
         return orderProductResponseList;
@@ -220,7 +220,7 @@ public class OrderServiceImpl implements OrderService {
             List<OrderProductEntity> products = orderProductRepository.findByOrderId(orderEntity.getId());
 
             for (OrderProductEntity product : products) {
-                ProductResponse productResponse = productService.getProduct(product.getProductId());
+                ProductResponse productResponse = productService.getProduct(product.getProductId()).getResult();
                 OrderProductResponse response = OrderProductResponse.fromEntity(
                         product,
                         productResponse.getName()

--- a/order-service/src/main/java/com/example/orderservice/service/StockService.java
+++ b/order-service/src/main/java/com/example/orderservice/service/StockService.java
@@ -24,6 +24,6 @@ public class StockService {
     }
 
     public BigDecimal fetchProductPrice(Long productId) {
-        return productService.getProduct(productId).getPrice();
+        return productService.getProduct(productId).getResult().getPrice();
     }
 }

--- a/user-service/src/main/java/com/example/userservice/service/UserServiceImpl.java
+++ b/user-service/src/main/java/com/example/userservice/service/UserServiceImpl.java
@@ -15,7 +15,6 @@ import com.example.userservice.util.EncryptionUtil;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -77,8 +76,8 @@ public class UserServiceImpl implements UserService {
         // 회원 정보와 주문 목록 반환
         UserEntity userEntity = getUserEntity(userId);
 
-        ResponseEntity<List<OrderProductResponse>> orders = orderServiceClient.getOrders(userId);
-        List<OrderProductResponse> orderList = (orders != null && orders.getBody() != null) ? orders.getBody() : Collections.emptyList();
+        List<OrderProductResponse> orders = orderServiceClient.getOrders(userId);
+        List<OrderProductResponse> orderList = (orders != null) ? orders : Collections.emptyList();
 
         return UserInfoResponse.fromEntity(UserEntity.decryptSensitiveData(userEntity), orderList);
     }


### PR DESCRIPTION
- OrderController: 기존 /order-service 경로 제거 및 API 요청 처리 시 @RequestHeader("X-User-Id")를 일부 경로에 적용
- OrderServiceImpl: ProductServiceClient의 응답 타입 변경에 따른 로직 수정
- ProductServiceClient: ApiResponse 래핑을 위한 getProduct 메서드 수정
- StockService: ProductServiceClient의 응답 타입에 맞게 fetchProductPrice 메서드 수정
- UserServiceImpl: OrderServiceClient의 응답 처리 방식 변경

주요 변경 이유:
- API 경로 일관성 및 가독성 향상
- 외부 서비스 클라이언트 응답 구조 변경에 따른 코드 반영